### PR TITLE
Db table prefix

### DIFF
--- a/src/Division.php
+++ b/src/Division.php
@@ -37,7 +37,7 @@ class Division extends \yii\db\ActiveRecord implements ModelInterface
      */
     public static function tableName()
     {
-        return 'division';
+        return '{{%division}}';
     }
 
     /**

--- a/src/DivisionTranslation.php
+++ b/src/DivisionTranslation.php
@@ -21,6 +21,6 @@ class DivisionTranslation extends \yii\db\ActiveRecord
      */
     public static function tableName()
     {
-        return 'division_translation';
+        return '{{%division_translation}}';
     }
 }


### PR DESCRIPTION
Two more files.
Models were not supporting db connection configured to use table prefix while migration did.